### PR TITLE
Revamp `is_confusable` to use proper greedy startegy for matching

### DIFF
--- a/confusables/__init__.py
+++ b/confusables/__init__.py
@@ -1,7 +1,10 @@
 import json
 import re
 import os
-from .config import CONFUSABLE_MAPPING_PATH
+from itertools import product
+
+from .config import CONFUSABLE_MAPPING_PATH, NON_NORMAL_ASCII_CHARS
+from .utils import is_ascii
 
 
 # read confusable mappings from file, build 2-way map of the pairs
@@ -10,37 +13,26 @@ with open(os.path.join(os.path.dirname(__file__), CONFUSABLE_MAPPING_PATH), "r")
 
 
 def is_confusable(str1, str2):
-    while str1 + str2:
-        if bool(str1) != bool(str2):
-            return False
+    while str1 and str2:
+        length1, length2 = 0, 0
+        for index in range(len(str1), 0, -1):
+            if str1[:index] in confusable_characters(str2[0]):
+                length1 = index
+                break
+        for index in range(len(str2), 0, -1):
+            if str2[:index] in confusable_characters(str1[0]):
+                length2 = index
+                break
 
-        if str1[0] == str2[0]:
-            str1 = str1[1:]
-            str2 = str2[1:]
-        elif str2[0] in CONFUSABLE_MAP.get(str1[0]):
-            str1 = str1[1:]
+        if not length1 and not length2:
+            return False
+        elif not length2 or length1 >= length2:
+            str1 = str1[length1:]
             str2 = str2[1:]
         else:
-            next = False
-            for index in range(1, len(str1) + 1):
-                if str1[:index] == CONFUSABLE_MAP.get(str2[0]):
-                    str1 = str1[index:]
-                    str2 = str2[1:]
-                    next = True
-                    break
-            if next:
-                continue
-
-            for index in range(1, len(str2) + 1):
-                if str2[:index] == CONFUSABLE_MAP.get(str1[0]):
-                    str2 = str2[index:]
-                    str1 = str1[1:]
-                    next = True
-                    break
-            if next:
-                continue
-            return False
-    return True
+            str1 = str1[1:]
+            str2 = str2[length2:]
+    return str1 == str2
 
 def confusable_characters(char):
     return CONFUSABLE_MAP.get(char)
@@ -53,3 +45,30 @@ def confusable_regex(string, include_character_padding=False):
     regex += "\\b"
 
     return regex
+
+def normalize(string, prioritize_alpha=False):
+    normal_forms = set([""])
+    for char in string:
+        normalized_chars = []
+        confusable_chars = confusable_characters(char)
+        if not is_ascii(char) or not char.isalpha():
+            for confusable in confusable_chars:
+                if prioritize_alpha:
+                    if ((char.isalpha() and confusable.isalpha() and is_ascii(confusable)) or (not char.isalpha() and is_ascii(confusable))) and confusable not in NON_NORMAL_ASCII_CHARS:
+                        normal = confusable
+                        if len(confusable) > 1:
+                            normal = normalize(confusable)[0]
+                        normalized_chars.append(normal)
+                else:
+                    if is_ascii(confusable) and confusable not in NON_NORMAL_ASCII_CHARS:
+                        normal = confusable
+                        if len(confusable) > 1:
+                            normal = normalize(confusable)[0]
+                        normalized_chars.append(normal)
+        else:
+            normalized_chars = [char]
+
+        if len(normalized_chars) == 0:
+            normalized_chars = [char]
+        normal_forms = set([x[0]+x[1].lower() for x in list(product(normal_forms, normalized_chars))])
+    return sorted(list(normal_forms))

--- a/confusables/config.py
+++ b/confusables/config.py
@@ -2,3 +2,4 @@ CUSTOM_CONFUSABLE_PATH = "assets/custom_confusables.txt"
 CONFUSABLES_PATH = "assets/confusables.txt"
 CONFUSABLE_MAPPING_PATH = "assets/confusable_mapping.json"
 MAX_SIMILARITY_DEPTH = 2
+NON_NORMAL_ASCII_CHARS = ['@']

--- a/confusables/utils.py
+++ b/confusables/utils.py
@@ -1,0 +1,5 @@
+def is_ascii(string):
+    for char in string:
+        if ord(char) >= 128:
+            return False
+    return True

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ long_description = open(os.path.join(os.path.dirname(__file__), 'README.md')).re
 
 setuptools.setup(
     name="confusables",
-    version="0.0.1",
+    version="0.1.0",
     author="Nathan Woodger",
     author_email="woodgern@gmail.com",
     description="A python package providing functionality for matching words using different characters but appearing to be similar/the same word.",

--- a/tests/confusables/test_confusables.py
+++ b/tests/confusables/test_confusables.py
@@ -3,12 +3,34 @@ import datetime
 from unittest.mock import Mock
 import re
 
-from confusables import is_confusable, confusable_characters, confusable_regex
+from confusables import is_confusable, confusable_characters, confusable_regex, normalize
 
 class TestConfusables(unittest.TestCase):
 
     def test_is_confusable__unicode_mapping_only(self):
         self.assertTrue(is_confusable('rover', 'Ʀỏ𝕍3ℛ'))
+
+    def test_is_confusable__multi_character_mapping(self):
+        self.assertTrue(is_confusable('Ʀỏ𝕍3ℛ', 'ro\'ver'))
+        self.assertTrue(is_confusable('ro\'ver', 'Ʀỏ𝕍3ℛ'))
+
+    def test_is_confusable__not_remotely_similar_words(self):
+        self.assertFalse(is_confusable('Ʀỏ𝕍3ℛ', 'salmon'))
+        self.assertFalse(is_confusable('salmon', 'Ʀỏ𝕍3ℛ'))
+
+    def test_is_confusable__prefix_does_not_give_false_positive(self):
+        self.assertFalse(is_confusable('Ʀỏ𝕍3ℛ', 'rover is my favourite dog'))
+        self.assertFalse(is_confusable('rover is my favourite dog', 'Ʀỏ𝕍3ℛ'))
+
+    def test_is_confusable__None_input(self):
+        self.assertTrue(is_confusable(None, None))
+        self.assertFalse(is_confusable('rover is my favourite dog', None))
+        self.assertFalse(is_confusable(None, 'rover is my favourite dog'))
+
+    def test_is_confusable__empty_input(self):
+        self.assertTrue(is_confusable('', ''))
+        self.assertFalse(is_confusable('rover is my favourite dog', ''))
+        self.assertFalse(is_confusable('', 'rover is my favourite dog'))
 
     def test_confusable_characters__is_two_way(self):
         for u in [chr(i) for i in range(65536)]:
@@ -17,9 +39,29 @@ class TestConfusables(unittest.TestCase):
                 for mapped_char in mapped_chars:
                     self.assertTrue(u in confusable_characters(mapped_char))
 
-    def test_confusable_regex__basic_ascii_regex(self):
+    def test_confusable_characters__no_confusables_returns_None(self):
+        self.assertEqual(confusable_characters(''), None)
+        self.assertEqual(confusable_characters('This is a long string that has no chance being confusable with a single character'), None)
+
+    def test_confusable_regex__regex_does_not_match_if_only_subset_of_word(self):
+        regex = confusable_regex('bore')
+        reg = re.compile(regex)
+        self.assertFalse(reg.search('Hopefully you don\'t get bored easily'))
+
+    def test_confusable_regex__basic_ascii_regex_with_padding(self):
         regex = confusable_regex('bore', include_character_padding=True)
         reg = re.compile(regex)
-        print(reg.search('Sometimes people say that life can be a ь.𝞂.ř.ɜ, but I don\'t agree'))
         self.assertTrue(reg.search('Sometimes people say that life can be a ь.𝞂.ř.ɜ, but I don\'t agree'))
-        self.assertFalse(reg.search('Hopefully you don\'t get bored easily'))
+
+    def test_confusable_regex__basic_ascii_regex_without_padding(self):
+        regex = confusable_regex('bore')
+        reg = re.compile(regex)
+        self.assertFalse(reg.search('Sometimes people say that life can be a ь.𝞂.ř.ɜ, but I don\'t agree'))
+        self.assertTrue(reg.search('Sometimes people say that life can be a ь𝞂řɜ, but I don\'t agree'))
+
+    def test_normalize__prioritize_alpha_True_and_False(self):
+        self.assertEqual(normalize('Ʀỏ𝕍3ℛ', prioritize_alpha=True), ['rov3r', 'rover'])
+        self.assertEqual(normalize('Ʀỏ𝕍3ℛ'), normalize('Ʀỏ𝕍3ℛ', prioritize_alpha=False), ['r0v3r', 'r0ver', 'ro\'v3r', 'ro\'ver', 'rov3r', 'rover'])
+
+    def test_normalize__at_character_gets_normalized(self):
+        self.assertEqual(normalize('te@time'), ['teatime'])


### PR DESCRIPTION
The purpose of this PR is to perform some repairs on the `is_confusable` function, and to add a new function, `normalize`. Documentation will be updated accordingly.