### PR TITLE
Add `match_subword` option to `confusable_regex`

### DIFF
--- a/confusables/__init__.py
+++ b/confusables/__init__.py
@@ -37,12 +37,13 @@ def is_confusable(str1, str2):
 def confusable_characters(char):
     return CONFUSABLE_MAP.get(char)
 
-def confusable_regex(string, include_character_padding=False):
+def confusable_regex(string, include_character_padding=False, match_subword=False):
     space_regex = "[\*|_|~|`|-|\.]*" if include_character_padding else ''
-    regex = "\\b" + space_regex
+    prepostfix = '' if match_subword else '\\b'
+    regex = prepostfix + space_regex
     for char in string:
         regex += "[" + "|".join(CONFUSABLE_MAP[char]) + "|" + char + "]" + space_regex
-    regex += "\\b"
+    regex += prepostfix
 
     return regex
 

--- a/tests/confusables/test_confusables.py
+++ b/tests/confusables/test_confusables.py
@@ -59,6 +59,12 @@ class TestConfusables(unittest.TestCase):
         self.assertFalse(reg.search('Sometimes people say that life can be a ь.𝞂.ř.ɜ, but I don\'t agree'))
         self.assertTrue(reg.search('Sometimes people say that life can be a ь𝞂řɜ, but I don\'t agree'))
 
+    def test_confusable_regex__match_subwords(self):
+        regex = confusable_regex('bore', match_subword=True)
+        reg = re.compile(regex)
+        self.assertTrue(reg.search('Sometimes people say that life can be a ь𝞂řɜd, but I don\'t agree'))
+        self.assertTrue(reg.search('Sometimes people say that life can be a ь𝞂řɜ, but I don\'t agree'))
+
     def test_normalize__prioritize_alpha_True_and_False(self):
         self.assertEqual(normalize('Ʀỏ𝕍3ℛ', prioritize_alpha=True), ['rov3r', 'rover'])
         self.assertEqual(normalize('Ʀỏ𝕍3ℛ'), normalize('Ʀỏ𝕍3ℛ', prioritize_alpha=False), ['r0v3r', 'r0ver', 'ro\'v3r', 'ro\'ver', 'rov3r', 'rover'])


### PR DESCRIPTION
This option makes it so that if true, it will match subwords (essentially a regular regex). Otherwise, it will work as before, which means it only matches the given word if it's surrounded by work break characters (the regex is pre and post fixed with `\b`)