### PR TITLE
Update so that all unicode characters are confusable with themselves

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,8 @@ regex = re.compile(regex_string)
 
 print(regex.search('Sometimes people say that life can be a ь.𝞂.ř.ɜ, but I don\'t agree'))
 # prints <_sre.SRE_Match object; span=(40, 47), match='ь.𝞂.ř.ɜ'>
-
-print(reg.search('Hopefully you don\'t get bored easily'))
-# prints None (bored has the word bore as a subset, but it is not a word on it's own)
 ```
+
 
 
 `normalize(string, prioritize_alpha=False)` takes a string and outputs a list of possible "normal forms". This means that characters in the string get converted to their confusable ascii counterparts. The `prioritize_alpha` option means the outputted options will prioritize converting characters to characters of the latin alphabet over any others. This option is recommended when natural language is expected.

--- a/confusables/__init__.py
+++ b/confusables/__init__.py
@@ -35,15 +35,18 @@ def is_confusable(str1, str2):
     return str1 == str2
 
 def confusable_characters(char):
-    return CONFUSABLE_MAP.get(char)
+    mapped_chars = CONFUSABLE_MAP.get(char)
+    if mapped_chars:
+        return mapped_chars
+    if len(char) <= 1:
+        return [char]
+    return None
 
-def confusable_regex(string, include_character_padding=False, match_subword=False):
+def confusable_regex(string, include_character_padding=False):
     space_regex = "[\*_~|`\-\.]*" if include_character_padding else ''
-    prepostfix = '' if match_subword else '\\b'
-    regex = prepostfix + space_regex
+    regex = space_regex
     for char in string:
-        regex += "[" + "|".join(CONFUSABLE_MAP[char]) + "|" + char + "]" + space_regex
-    regex += prepostfix
+        regex += "[" + "|".join(confusable_characters(char)) + "]" + space_regex
 
     return regex
 

--- a/tests/confusables/test_confusables.py
+++ b/tests/confusables/test_confusables.py
@@ -33,20 +33,20 @@ class TestConfusables(unittest.TestCase):
         self.assertFalse(is_confusable('', 'rover is my favourite dog'))
 
     def test_confusable_characters__is_two_way(self):
-        for u in [chr(i) for i in range(65536)]:
+        for u in [chr(i) for i in range(137928)]:
             mapped_chars = confusable_characters(u)
             if mapped_chars:
                 for mapped_char in mapped_chars:
                     self.assertTrue(u in confusable_characters(mapped_char))
 
-    def test_confusable_characters__no_confusables_returns_None(self):
-        self.assertEqual(confusable_characters(''), None)
-        self.assertEqual(confusable_characters('This is a long string that has no chance being confusable with a single character'), None)
+    def test_confusable_characters__no_confusables_returns_input_character_if_length_is_zero(self):
+        self.assertEqual(confusable_characters(''), [''])
 
-    def test_confusable_regex__regex_does_not_match_if_only_subset_of_word(self):
-        regex = confusable_regex('bore')
-        reg = re.compile(regex)
-        self.assertFalse(reg.search('Hopefully you don\'t get bored easily'))
+    def test_confusable_characters__no_confusables_returns_input_character_if_length_is_one(self):
+        self.assertEqual(confusable_characters('#'), ['#'])
+
+    def test_confusable_characters__no_confusables_returns_none_if_length_is_not_one(self):
+        self.assertEqual(confusable_characters('This is a long string that has no chance being confusable with a single character'), None)
 
     def test_confusable_regex__basic_ascii_regex_with_padding(self):
         regex = confusable_regex('bore', include_character_padding=True)
@@ -60,7 +60,7 @@ class TestConfusables(unittest.TestCase):
         self.assertTrue(reg.search('Sometimes people say that life can be a ь𝞂řɜ, but I don\'t agree'))
 
     def test_confusable_regex__match_subwords(self):
-        regex = confusable_regex('bore', match_subword=True)
+        regex = confusable_regex('bore')
         reg = re.compile(regex)
         self.assertTrue(reg.search('Sometimes people say that life can be a ь𝞂řɜd, but I don\'t agree'))
         self.assertTrue(reg.search('Sometimes people say that life can be a ь𝞂řɜ, but I don\'t agree'))


### PR DESCRIPTION
Changed so that the `confusable_characters()` function considers all unicode

characters are considered confusable with themself, including ones that
are not in the unicode mapping.

Additionally, removed option to have `confusable_regex()` match subwords, and
made subword matching the default and only behaviour