### PR TITLE
Script to Automatically Generate Custom Mapping Entries

### DIFF
--- a/confusables/Custom Confusable String Maker.py
+++ b/confusables/Custom Confusable String Maker.py
@@ -1,0 +1,86 @@
+#-*- coding: UTF-8 -*-
+
+# Script Purpose: Automatically generates additional entries for 'custom_confusables.txt', for confusable character combinations that are not included by default. 
+#                 Remember: After adding all the characters you want, you must then still run parse.py to generate the new 'confusable_mapping.json' file
+
+# ------------------------------------ Only Change This Section ------------------------------------
+
+# THESE TWO VARIABLES ARE THE ONLY THINGS YOU NEED TO CHANGE
+# Ensure the spammified phrases and real phrases line up exactly, as each character will be compared to it's counterpart in the other variable
+spammifiedPhrase = "ＦＲＥＥ ＲＯＢＵＸ on мy proғιle"
+realPhrase = "FREE ROBUX ON MY PROFILE"
+
+
+# ---------------------------------------------------------------------------------------------------
+import sys
+import os
+import json
+
+# Code in this section taken from __init__.py
+from config import CONFUSABLE_MAPPING_PATH
+# read confusable mappings from file, build 2-way map of the pairs
+with open(os.path.join(os.path.dirname(__file__), CONFUSABLE_MAPPING_PATH), "r") as mappings:
+    CONFUSABLE_MAP = json.loads(mappings.readline())
+def confusable_characters(char):
+    mapped_chars = CONFUSABLE_MAP.get(char)
+    if mapped_chars:
+        return mapped_chars
+    if len(char) <= 1:
+        return [char]
+    return None
+# ---------------------------------------------------------------------------------------------------
+def check_char(realLetterLower, letterInSpam):
+    realLetterUpper = realLetterLower.upper()
+    if realLetterLower == letterInSpam or realLetterUpper == letterInSpam:
+        print(f"{letterInSpam} is Normal Letter")
+    else:
+        confuseChars = confusable_characters(realLetterLower)
+        confuseCharsUpper = confusable_characters(realLetterUpper)
+
+        if letterInSpam in confuseChars:
+            print(f"Confusable Combo {realLetterLower}:{letterInSpam} Already Included in Confusables")
+        else:
+            makeStringList.append({realLetterLower:letterInSpam})
+
+        if letterInSpam in confuseCharsUpper:
+            print(f"Confusable Combo {realLetterUpper}:{letterInSpam} Already Included in Confusables")
+        else:
+            makeStringList.append({realLetterUpper:letterInSpam})
+
+def make_string(realLetter, letterInSpam):
+    tab = ' '
+    spamHex = format(ord(letterInSpam), 'x')
+    spamHexFormatted = spamHex.rjust(4, str(0)).upper()
+
+    letterHex = format(ord(realLetter), 'x')
+    letterHexFormatted = letterHex.rjust(4, str(0)).upper()
+
+    finalString = f"{letterHexFormatted}{tab};{tab}{spamHexFormatted}{tab};{tab}#{tab}{realLetter}{tab}→{tab}{letterInSpam}"
+    print(finalString)
+
+
+spammifiedPhrase = spammifiedPhrase.replace(" ", "")
+realPhrase = realPhrase.replace(" ", "").lower()
+
+makeStringList = []
+
+for i in range(len(spammifiedPhrase)):
+    check_char(realPhrase[i], spammifiedPhrase[i])
+
+
+if makeStringList:
+    print("------------------------------------------------------------------")
+    print("-------------------------- Pairs to Add --------------------------")
+    print("------------------------------------------------------------------")
+else:
+    print("------------------------------------------------------------------\n")
+    print("All pairs are either normal characters or are already included in the confusables mapping.\n")
+    input("Press Enter to Exit")
+    sys.exit()
+
+for charDict in makeStringList:
+    make_string(list(charDict.keys())[0], list(charDict.values())[0])
+
+print("\n------------------------------------------------------------------\n")
+input("Entries Generated Above. Press Enter to Exit")
+sys.exit()

--- a/confusables/Custom Confusable String Maker.py
+++ b/confusables/Custom Confusable String Maker.py
@@ -63,9 +63,14 @@ spammifiedPhrase = spammifiedPhrase.replace(" ", "")
 realPhrase = realPhrase.replace(" ", "").lower()
 
 makeStringList = []
+alreadyCheckedCharList = []
 
 for i in range(len(spammifiedPhrase)):
-    check_char(realPhrase[i], spammifiedPhrase[i])
+    if spammifiedPhrase[i] in alreadyCheckedCharList:
+        continue
+    else:
+        alreadyCheckedCharList.append(spammifiedPhrase[i])
+        check_char(realPhrase[i], spammifiedPhrase[i])
 
 
 if makeStringList:


### PR DESCRIPTION
Adds script to automatically check if confusable pairs are already mapped or not, and generate those entries for custom_confusables.txt. It is run independently of the rest of the module, but does need to be in the same folder as config.py.

Example usage by editing these two variables in the script:
```
spammifiedPhrase = "ＦＲＥＥ ＲＯＢＵＸ on мy proғιle"
realPhrase = "FREE ROBUX ON MY PROFILE"
```

Output:
<img width="508" alt="image" src="https://user-images.githubusercontent.com/12518330/161864642-7129c8d0-ea27-4c52-8c1d-48a8e685c1e6.png">

